### PR TITLE
Fix bug using internal javascript files to allow SSL

### DIFF
--- a/helpers/NeatlineTimeFunctions.php
+++ b/helpers/NeatlineTimeFunctions.php
@@ -60,6 +60,9 @@ function queue_timeline_assets()
     $useInternalJs = isset($config->theme->useInternalJavascripts)
             ? (bool) $config->theme->useInternalJavascripts
             : false;
+    $useInternalJs = isset($config->theme->useInternalAssets)
+            ? (bool) $config->theme->useInternalAssets
+            : $useInternalJs;
 
     if ($useInternalJs) {
         $timelineVariables = 'Timeline_ajax_url="'.src('simile-ajax-api.js', 'javascripts/simile/ajax-api').'"; '
@@ -69,7 +72,7 @@ function queue_timeline_assets()
         $headScript->appendScript($timelineVariables);
         $headScript->appendFile(src('timeline-api.js', 'javascripts/simile/timeline-api'));
     } else {
-        $headScript->appendFile('https://api.simile-widgets.org/timeline/2.3.1/timeline-api.js?bundle=true');
+        $headScript->appendFile('//api.simile-widgets.org/timeline/2.3.1/timeline-api.js?bundle=true');
     }
 
     $headScript->appendScript('SimileAjax.History.enabled = false; window.jQuery = SimileAjax.jQuery');

--- a/helpers/NeatlineTimeFunctions.php
+++ b/helpers/NeatlineTimeFunctions.php
@@ -69,7 +69,7 @@ function queue_timeline_assets()
         $headScript->appendScript($timelineVariables);
         $headScript->appendFile(src('timeline-api.js', 'javascripts/simile/timeline-api'));
     } else {
-        $headScript->appendFile('http://api.simile-widgets.org/timeline/2.3.1/timeline-api.js?bundle=true');
+        $headScript->appendFile('https://api.simile-widgets.org/timeline/2.3.1/timeline-api.js?bundle=true');
     }
 
     $headScript->appendScript('SimileAjax.History.enabled = false; window.jQuery = SimileAjax.jQuery');


### PR DESCRIPTION
I noticed that on newer versions of Omeka, this plugin was failing when my site loaded using https because of dynamic loaded of external scripts that are hard coded to use http. I noticed that the plugin supports using local javascript files, which fixes this problem neatly, but that functionality was not working with my Omeka 2.4 installation. 
It looks like this is caused by a syntax change in the Omeka config.ini file that happened a few years back: https://github.com/omeka/Omeka/issues/305
I made a quick change that fixes the issue. 
I also removed the "http" from one dynamically loaded script so that it could load using the protocol of the parent page if need be, but this alone will not get the timeline to work on a page loaded with SSL.
