### PR TITLE
Fixes default values for date columns.

### DIFF
--- a/NeatlineTimePlugin.php
+++ b/NeatlineTimePlugin.php
@@ -55,8 +55,8 @@ class NeatlineTimePlugin extends Omeka_Plugin_AbstractPlugin
             `creator_id` INT UNSIGNED NOT NULL,
             `public` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0',
             `featured` TINYINT(1) NOT NULL DEFAULT '0',
-            `center_date` date NOT NULL default '0000-00-00',
-            `added` timestamp NOT NULL default '0000-00-00 00:00:00',
+            `center_date` date NOT NULL default '2018-01-01',
+            `added` timestamp NOT NULL default CURRENT_TIMESTAMP,
             `modified` timestamp NOT NULL default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP,
             PRIMARY KEY (`id`)
             ) ENGINE=innodb DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
@@ -112,7 +112,7 @@ class NeatlineTimePlugin extends Omeka_Plugin_AbstractPlugin
             }
         }
 
-        if (version_compare($oldversion, '2.1', '<')) {
+        if (version_compare($oldVersion, '2.1', '<')) {
           $rows = $this->_db->query(
             "show columns from {$this->_db->prefix}neatline_time_timelines where field='center_date';"
           );
@@ -123,6 +123,12 @@ class NeatlineTimePlugin extends Omeka_Plugin_AbstractPlugin
 
             $this->_db->query($sqlNeatlineTimeline);
           }
+        }
+
+        if (version_compare($oldVersion, '2.1.1', '<')) {
+            $sql = "ALTER TABLE `{$this->_db->prefix}neatline_time_timelines`
+            MODIFY COLUMN `center_date` date NOT NULL default '2018-01-01',
+            MODIFY COLUMN `added` timestamp NOT NULL default CURRENT_TIMESTAMP";
         }
     }
 

--- a/plugin.ini
+++ b/plugin.ini
@@ -5,7 +5,7 @@
   link="http://neatline.org/"
   omeka_minimum_version="2.0"
   omeka_tested_up_to="2.3"
-  version="2.1.0"
+  version="2.1.1"
   tags="timelines, chronology"
   support_link="http://github.com/scholarslab/NeatlineTime/issues"
   omeka_target_version="2.0"


### PR DESCRIPTION
Strict mode in MySQL 5.7, enabled by default, throws an exception when
0000-00-00 and similar placeholders are used for default values for date
and timestamp columns.

Fixes #86.